### PR TITLE
Minor change to Dutch translation

### DIFF
--- a/public/locales/nl/translation.json
+++ b/public/locales/nl/translation.json
@@ -8,7 +8,7 @@
     },
     "navbar": {
         "created_with_<3_by": "gemaakt met ❤️ door",
-        "visit_github": "Bezoek ons GitHub-repositorium",
+        "visit_github": "Bezoek onze GitHub-pagina",
         "visit_osmp_website": "Bezoek OpenStreetMap Poland's website"
     },
     "sidebar": {


### PR DESCRIPTION
You may choose to change "Bezoek ons GitHub-repositorium" to "Bezoek onze GitHub-pagina". (this sounds better)
Notably, the original text is "repository" -not "page"- and all languages currently use a direct translation of this word.