### PR TITLE
add REACT_APP_ENV variable

### DIFF
--- a/.github/workflows/deploy_development.yml
+++ b/.github/workflows/deploy_development.yml
@@ -29,7 +29,7 @@ jobs:
       run: npm run test
     - name: Build app
       env:
-        NODE_ENV: development
+        REACT_APP_ENV: development
         REACT_APP_OSM_API_URL: ${{ secrets.REACT_APP_OSM_API_URL }}
         REACT_APP_OSM_OAUTH2_CLIENT_ID: ${{ secrets.REACT_APP_OSM_OAUTH2_CLIENT_ID }}
         REACT_APP_OSM_OAUTH2_CLIENT_SECRET: ${{ secrets.REACT_APP_OSM_OAUTH2_CLIENT_SECRET }}

--- a/.github/workflows/deploy_production.yml
+++ b/.github/workflows/deploy_production.yml
@@ -29,7 +29,7 @@ jobs:
       run: npm run test
     - name: Build app
       env:
-        NODE_ENV: production
+        REACT_APP_ENV: production
         REACT_APP_OSM_API_URL: ${{ secrets.REACT_APP_OSM_API_URL }}
         REACT_APP_OSM_OAUTH2_CLIENT_ID: ${{ secrets.REACT_APP_OSM_OAUTH2_CLIENT_ID }}
         REACT_APP_OSM_OAUTH2_CLIENT_SECRET: ${{ secrets.REACT_APP_OSM_OAUTH2_CLIENT_SECRET }}

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -3,7 +3,7 @@ import { initReactI18next } from 'react-i18next';
 import LanguageDetector from 'i18next-browser-languagedetector';
 import Backend from 'i18next-http-backend';
 
-const isProduction = process.env.NODE_ENV === 'production';
+const isProduction = process.env.REACT_APP_ENV === 'production';
 
 const languages = {
   en: { nativeName: 'English' },


### PR DESCRIPTION
https://github.com/openstreetmap-polska/openaedmap-frontend/issues/52

We can't override NODE_ENV which is always set to production when running `npm run build`. This PR introduce custom env variable: REACT_APP_ENV.