### PR TITLE
feat(src/i18n.ts): add Simplified Chinese (`zh_Hans`) and sort by langcode

### DIFF
--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -10,12 +10,12 @@ const languages: { [index: string]: {nativeName: string} } = {
   de: { nativeName: 'Deutsch' },
   en: { nativeName: 'English' },
   es: { nativeName: 'Español' },
+  fi: { nativeName: 'Suomi' },
   fr: { nativeName: 'Français' },
   it: { nativeName: 'Italiano' },
   nl: { nativeName: 'Nederlands' },
   pl: { nativeName: 'Polski' },
   sl: { nativeName: 'Slovenščina' },
-  fi: { nativeName: 'Suomi' },
 };
 if (!isProduction) {
   languages['debug'] = { nativeName: '--debug--'}

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -16,6 +16,7 @@ const languages: { [index: string]: {nativeName: string} } = {
   nl: { nativeName: 'Nederlands' },
   pl: { nativeName: 'Polski' },
   sl: { nativeName: 'Slovenščina' },
+  zh_Hans: { nativeName: '简体中文' },
 };
 if (!isProduction) {
   languages['debug'] = { nativeName: '--debug--'}


### PR DESCRIPTION
Hello maintainers, this PR will:

+ Sort language by langcode not by native name, because we may meet with non-latin character language and can't simply compared.
+ Add Simplified Chinese (`zh_Hans`) but this will violate current translation guideline because it isn't only have 2 letter:

https://github.com/openstreetmap-polska/openaedmap-frontend/blob/c92363ccbae632bc4da135e6f1126bd0b340ece8/README.md?plain=1#L28

(But I think the guideline should be changed, or `pt-BR` also can't be added to this project)

---
Close #84 