### PR TITLE
Disable animation when using geolocation

### DIFF
--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -240,6 +240,9 @@ const MapView: FC<MapViewProps> = ({ openChangesetId, setOpenChangesetId }) => {
 				positionOptions: {
 					enableHighAccuracy: true,
 				},
+				fitBoundsOptions: {
+      				animate: false,
+    			}
 			}),
 			controlsLocation,
 		);

--- a/src/components/map.tsx
+++ b/src/components/map.tsx
@@ -241,8 +241,8 @@ const MapView: FC<MapViewProps> = ({ openChangesetId, setOpenChangesetId }) => {
 					enableHighAccuracy: true,
 				},
 				fitBoundsOptions: {
-      				animate: false,
-    			}
+					animate: false,
+				},
 			}),
 			controlsLocation,
 		);


### PR DESCRIPTION
In an emergency, waiting a few seconds for the camera to move to our location is not desirable.