### PR TITLE
docs: add CI status badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Translation status](https://hosted.weblate.org/widgets/openaedmap/-/svg-badge.svg)](https://hosted.weblate.org/engage/openaedmap/)
+[![Translation status](https://hosted.weblate.org/widgets/openaedmap/-/svg-badge.svg)](https://hosted.weblate.org/engage/openaedmap/) [![CI](https://github.com/openstreetmap-polska/openaedmap-frontend/actions/workflows/ci_test.yml/badge.svg)](https://github.com/openstreetmap-polska/openaedmap-frontend/actions/workflows/ci_test.yml)
 
 # Open AED Map
 
@@ -33,7 +33,7 @@ Language with multiple variants needs extra suffix e.g. zh-Hant for Traditional 
 
 Status:
 
-[![Translation status](https://hosted.weblate.org/widgets/openaedmap/-/multi-auto.svg)](https://hosted.weblate.org/engage/openaedmap/)
+[![Translation status](https://hosted.weblate.org/widgets/openaedmap/-/multi-auto.svg)](https://hosted.weblate.org/engage/openaedmap/) [![CI](https://github.com/openstreetmap-polska/openaedmap-frontend/actions/workflows/ci_test.yml/badge.svg)](https://github.com/openstreetmap-polska/openaedmap-frontend/actions/workflows/ci_test.yml)
 
 ## Local environment
 


### PR DESCRIPTION
Adds a GitHub Actions CI badge to the README so the build status is visible at a glance.

The badge links to the `ci_test.yml` workflow.